### PR TITLE
Implement JSON-RPC LED control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # pico_mcp
 MCP for Raspberry Pi Pico
+
+## LED Control via JSON-RPC
+
+The firmware exposes a `mcp.call` JSON-RPC method. When the
+`location` field matches the value configured with `mcp.set_context`,
+calling `mcp.call` with `switch_id` set to `led` and `state` set to
+`"ON"` or `"OFF"` toggles the onboard LED.
+
+Example request:
+
+```json
+{"jsonrpc": "2.0", "id": 1, "method": "mcp.call", "params": {"location": "office", "switch_id": "led", "state": "ON"}}
+```
+
+This will turn the LED on when `location` equals `office` in the stored
+context.

--- a/pico_mcp.c
+++ b/pico_mcp.c
@@ -130,9 +130,10 @@ void handle_call(JSON_Object *params, int id)
 		return;
 	}
 
-	if (strcmp(loc, context.location) == 0) {
-		printf("{\"jsonrpc\": \"2.0\", \"result\": {\"success\": true, \"url\": \"%s\", \"switch_id\": \"%s\", \"state\": \"%s\"}, \"id\": %d}\n",
-			context.url, switch_id, state, id);
+        if (strcmp(loc, context.location) == 0) {
+                switch_led(state);
+                printf("{\"jsonrpc\": \"2.0\", \"result\": {\"success\": true, \"url\": \"%s\", \"switch_id\": \"%s\", \"state\": \"%s\"}, \"id\": %d}\n",
+                        context.url, switch_id, state, id);
 	}
 	else {
 		printf("{\"jsonrpc\": \"2.0\", \"error\": {\"code\": -32001, \"message\": \"Location not configured\"}, \"id\": %d}\n", id);


### PR DESCRIPTION
## Summary
- handle `mcp.call` to toggle the onboard LED
- document how to toggle the LED via JSON-RPC

## Testing
- `cmake ..` *(fails: SDK location was not specified)*

------
https://chatgpt.com/codex/tasks/task_e_68403859a7688324aa651303810b3d74