### PR TITLE
Add setup and build instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# Repository Instructions
+
+## Environment Setup
+
+1. Create a working directory for the Pico SDK:
+   ```bash
+   mkdir -p ~/.pico-sdk/sdk
+   ```
+2. Clone the Pico SDK (release 2.1.1) and initialize submodules:
+   ```bash
+   cd ~/.pico-sdk/sdk
+   git clone -b 2.1.1 https://github.com/raspberrypi/pico-sdk.git 2.1.1
+   cd 2.1.1
+   git submodule update --init
+   ```
+3. Set the environment variable pointing to the SDK path:
+   ```bash
+   export PICO_SDK_PATH=$HOME/.pico-sdk/sdk/2.1.1
+   ```
+
+After completing these steps, the SDK will be available under `~/.pico-sdk/sdk/2.1.1`.
+
+## Build Instructions
+
+Run the following commands from the repository root to fetch the Pico SDK (if needed) and build the project:
+
+```bash
+mkdir build
+cd build
+cmake -E env PICO_SDK_FETCH_FROM_GIT=1 cmake ..
+make -j$(nproc)
+```
+
+Successful builds generate artifacts such as `pico_mcp.uf2` inside the `build` directory.


### PR DESCRIPTION
## Summary
- provide environment setup steps and build instructions in `AGENTS.md`

## Testing
- `cmake -E env PICO_SDK_FETCH_FROM_GIT=1 cmake ..` *(fails: unable to access 'https://github.com/raspberrypi/pico-sdk/': CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_684ae68ca3fc8324b00bcadaf60e2cd9