### PR TITLE
Exclude third-party libs from formatting

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,0 +1,23 @@
+{
+  "Version": "v3.3.0",
+  "Verbose": false,
+  "Format": "",
+  "Debug": false,
+  "IgnoreDefaults": false,
+  "SpacesAfterTabs": false,
+  "NoColor": false,
+  "Exclude": [
+    "^llhttp/",
+    "^parson/"
+  ],
+  "AllowedContentTypes": [],
+  "PassedFiles": [],
+  "Disable": {
+    "EndOfLine": false,
+    "Indentation": false,
+    "InsertFinalNewline": false,
+    "TrimTrailingWhitespace": false,
+    "IndentSize": false,
+    "MaxLineLength": false
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,3 +32,13 @@ make -j$(nproc)
 ```
 
 Successful builds generate artifacts such as `pico_mcp.uf2` inside the `build` directory.
+
+## Formatting
+
+The repository defines a `.editorconfig` file. When editing code, ensure your changes follow these rules. The `.editorconfig-checker.json` file excludes the `parson` and `llhttp` directories. Run the following command from the repository root before committing:
+
+```bash
+npx --yes editorconfig-checker
+```
+
+Only commit changes when this check succeeds.

--- a/pico_mcp.c
+++ b/pico_mcp.c
@@ -62,13 +62,13 @@ static const char base64url_chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmno
 void base64url_encode_3bytes(const uint8_t *in, char *out, int len) {
 	uint32_t val = 0;
 	val |= len > 0 ? in[0] << 16 : 0;
-    val |= len > 1 ? in[1] << 8  : 0;
-    val |= len > 2 ? in[2]      : 0;
+	val |= len > 1 ? in[1] << 8  : 0;
+	val |= len > 2 ? in[2]      : 0;
 
 	out[0] = base64url_chars[(val >> 18) & 0x3F];
 	out[1] = base64url_chars[(val >> 12) & 0x3F];
 	out[2] = (len > 1) ? base64url_chars[(val >> 6) & 0x3F] : '\0';
-    out[3] = (len > 2) ? base64url_chars[val & 0x3F]        : '\0';
+	out[3] = (len > 2) ? base64url_chars[val & 0x3F]        : '\0';
 }
 
 // 16バイト → Base64URL（最大22文字＋null終端）
@@ -97,12 +97,12 @@ static void srv_txt(struct mdns_service *service, void *txt_userdata)
 	err_t res;
 	LWIP_UNUSED_ARG(txt_userdata);
 
-    res = mdns_resp_add_service_txtitem(service, "path=/sse", strlen("path=/sse"));
-	LWIP_ERROR("mdns add service txt failed\n", (res == ERR_OK), return);
-    res = mdns_resp_add_service_txtitem(service, "proto=json-rpc", strlen("proto=json-rpc"));
-	LWIP_ERROR("mdns add service txt failed\n", (res == ERR_OK), return);
-    res = mdns_resp_add_service_txtitem(service, "feature=mcp", strlen("feature=mcp"));
-	LWIP_ERROR("mdns add service txt failed\n", (res == ERR_OK), return);
+	res = mdns_resp_add_service_txtitem(service, "path=/sse", strlen("path=/sse"));
+LWIP_ERROR("mdns add service txt failed\n", (res == ERR_OK), return);
+	res = mdns_resp_add_service_txtitem(service, "proto=json-rpc", strlen("proto=json-rpc"));
+LWIP_ERROR("mdns add service txt failed\n", (res == ERR_OK), return);
+	res = mdns_resp_add_service_txtitem(service, "feature=mcp", strlen("feature=mcp"));
+LWIP_ERROR("mdns add service txt failed\n", (res == ERR_OK), return);
 }
 #endif
 


### PR DESCRIPTION
## Summary
- ignore `parson` and `llhttp` folders in formatting checks
- note the exclusion in `AGENTS.md`
- fix indentation flagged by editorconfig-checker

## Testing
- `npx --yes editorconfig-checker -v`


------
https://chatgpt.com/codex/tasks/task_e_684d09d95c988324b99a80cf4924c557