### PR TITLE
Switch to ATX power pulse GPIO control

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,5 +1,5 @@
 {
-  "Version": "v3.3.0",
+  "Version": "v3.6.0",
   "Verbose": false,
   "Format": "",
   "Debug": false,
@@ -8,7 +8,11 @@
   "NoColor": false,
   "Exclude": [
     "^llhttp/",
-    "^parson/"
+    "^parson/",
+    "^./llhttp/",
+    "^./parson/",
+    "llhttp/.*",
+    "parson/.*"
   ],
   "AllowedContentTypes": [],
   "PassedFiles": [],

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # MCP for Raspberry Pi Pico W
 
-## LED Control via JSON-RPC
+## ATX Power Button Pulse via JSON-RPC
 
 The firmware exposes JSON-RPC tools that can be invoked using the `tools/call` method. Use `tools/list` to discover available tools:
 `set_location`, `set_switch_id`, and `set_switch`.
-These allow you to configure the target switch and toggle the onboard LED.
+These allow you to configure the target switch and trigger a momentary ATX PWR_SW pulse.
 
 Example requests:
 
@@ -26,9 +26,16 @@ Example requests:
   "id": 3 }
 ```
 
-Call `set_switch` with `"state": "on"` or `"off"`. The LED changes only when the
+Call `set_switch` with `"state": "on"` or `"off"`; the state value is accepted for
+compatibility but always triggers a single pulse. The pulse fires only when the
 request's `location` or `switch_id` matches the previously set values or when
 both fields are omitted.
+
+GPIO configuration defaults (adjust in `pico_mcp.c`):
+
+- `ATX_PWR_SW_GPIO` (GPIO number)
+- `ATX_PWR_SW_ACTIVE_LEVEL` (active-high or active-low)
+- `ATX_PWR_SW_PULSE_MS` (pulse width in ms, default 200ms)
 
 ## How it works
 

--- a/pico_mcp.c
+++ b/pico_mcp.c
@@ -19,6 +19,9 @@
 #define HTTP_NEWLINE "\r\n"
 #define SSE_NEWLINE "\n"
 #define SSE_SEPARATOR "\n"
+#define ATX_PWR_SW_GPIO 2
+#define ATX_PWR_SW_ACTIVE_LEVEL 0
+#define ATX_PWR_SW_PULSE_MS 200
 
 enum endpoint_type {
 	ENDPOINT_NONE,
@@ -47,7 +50,7 @@ typedef struct session_info {
 static session_info_t *head = NULL;
 static char hostname[sizeof(CYW43_HOST_NAME) + 4];
 static int response_id = 1;
-static bool led_on = false;
+static bool pulse_in_progress = false;
 
 static int on_method(llhttp_t *parser, const char *at, size_t length);
 static int on_method_complete(llhttp_t *parser);
@@ -170,28 +173,32 @@ static char *get_query_value(const char *query, const char *key) {
 	return NULL; // 見つからない場合
 }
 
-static void switch_led(const char *val)
+static void init_atx_power_gpio(void)
 {
-	if (!val) {
-		return;
-	}
+	gpio_init(ATX_PWR_SW_GPIO);
+	gpio_set_dir(ATX_PWR_SW_GPIO, GPIO_OUT);
+	gpio_put(ATX_PWR_SW_GPIO, !ATX_PWR_SW_ACTIVE_LEVEL);
+	// ATX PWR_SWは短絡で動作するため、トランジスタ/フォトカプラ等で絶縁推奨。
+}
 
-	if (strcasecmp(val, "on") == 0) {
-		led_on = true;
-	} else if (strcasecmp(val, "off") == 0) {
-		led_on = false;
+static bool atx_power_pulse(void)
+{
+	if (pulse_in_progress) {
+		return false;
 	}
+	pulse_in_progress = true;
 
-	cyw43_gpio_set(&cyw43_state, 0, led_on);
+	gpio_put(ATX_PWR_SW_GPIO, ATX_PWR_SW_ACTIVE_LEVEL);
+	sleep_ms(ATX_PWR_SW_PULSE_MS);
+	gpio_put(ATX_PWR_SW_GPIO, !ATX_PWR_SW_ACTIVE_LEVEL);
+
+	pulse_in_progress = false;
+	return true;
 }
 
 const char *get_switch_state()
 {
-	if (led_on) {
-		return "on";
-	} else {
-		return "off";
-	}
+	return "pulse";
 }
 
 static void session_info_free(session_info_t *info)
@@ -380,6 +387,7 @@ int response_printf(session_info_t *info, const char *format, ...)
 const char invalid_request[] = "{\"jsonrpc\":\"2.0\",\"id\":%d,\"error\":{\"code\":-32600,\"message\":\"Invalid Request\"}}";
 const char method_not_found[] = "{\"jsonrpc\":\"2.0\",\"id\":%d,\"error\":{\"code\":-32601,\"message\":\"Method not found\"}}";
 const char location_not_configured[] = "{\"jsonrpc\": \"2.0\", \"error\": {\"code\": -32001, \"message\": \"Location not configured\"}, \"id\": %d}";
+const char pulse_busy[] = "{\"jsonrpc\": \"2.0\", \"error\": {\"code\": -32002, \"message\": \"Power pulse busy\"}, \"id\": %d}";
 const char unknown_tool[] = "{\"jsonrpc\":\"2.0\",\"id\":%d,\"error\":{\"code\":-32602,\"message\":\"Unknown tool\"}}";
 const char invalid_protocol[] = "{\"jsonrpc\":\"2.0\",\"id\":%d,\"error\":{\"code\":-32602,\"message\":\"Invalid protocol version\"}}";
 const char invalid_context[] = "{\"jsonrpc\": \"2.0\", \"error\": {\"code\": -32602, \"message\": \"Invalid context\"}, \"id\": %d}";
@@ -389,7 +397,7 @@ const char parse_error[] = "{\"jsonrpc\":\"2.0\",\"id\":%d,\"error\":{\"code\":-
 
 const char resource[] = "{\"jsonrpc\":\"2.0\",\"id\":%d,\"result\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{\"logging\":{},\"tools\":{\"listChanged\":true}},\"serverInfo\":{\"name\":\"Raspberry Pi Pico Smart Home\",\"description\":\"A smart home system based on Raspberry Pi Pico.\",\"version\":\"1.0.0.0\"}}}";
 const char tool_list[] = "{\"jsonrpc\":\"2.0\",\"id\":%d,\"result\":{\"tools\":["
-		"{\"name\":\"set_switch\",\"description\":\"Use this to toggle a light or other switch ON or OFF.\",\"inputSchema\":{\"title\":\"set_switch\",\"description\":\"Use this to toggle a light or other switch ON or OFF.\",\"type\":\"object\",\"properties\":{\"switch_id\":{\"type\":\"string\"},\"location\":{\"type\":\"string\"},\"state\":{\"type\":\"string\",\"enum\":[\"on\",\"off\"]}},\"required\":[\"state\"]}},"
+		"{\"name\":\"set_switch\",\"description\":\"Trigger a momentary power button pulse.\",\"inputSchema\":{\"title\":\"set_switch\",\"description\":\"Trigger a momentary power button pulse.\",\"type\":\"object\",\"properties\":{\"switch_id\":{\"type\":\"string\"},\"location\":{\"type\":\"string\"},\"state\":{\"type\":\"string\",\"enum\":[\"on\",\"off\"]}},\"required\":[\"state\"]}},"
 		"{\"name\":\"set_location\",\"description\":\"Set the location of the switch.\",\"inputSchema\":{\"title\":\"set_location\",\"description\":\"Set the location of the switch.\",\"type\":\"object\",\"properties\":{\"switch_id\":{\"type\":\"string\"},\"location\":{\"type\":\"string\"}},\"required\":[\"location\"]}},"
 		"{\"name\":\"set_switch_id\",\"description\":\"Set the ID of the switch.\",\"inputSchema\":{\"title\":\"set_switch_id\",\"description\":\"Set the ID of the switch.\",\"type\":\"object\",\"properties\":{\"switch_id\":{\"type\":\"string\"},\"location\":{\"type\":\"string\"}},\"required\":[\"switch_id\"]}}"
 	"]}}";
@@ -450,9 +458,13 @@ void handle_set_switch(session_info_t *info, JSON_Object *arguments, int id)
 	if ((location && strcmp(location, context.location) == 0)
 		|| (switch_id && strcmp(switch_id, context.switch_id) == 0)
 		|| (!location && !switch_id)) {
-		switch_led(state);
+		LWIP_UNUSED_ARG(state);
+		if (!atx_power_pulse()) {
+			response_printf(info, pulse_busy, id);
+			return;
+		}
 		char content[256];
-		sprintf(content, "{\"switch_id\":\"%s\",\"location\":\"%s\",\"state\":\"%s\"}",
+		sprintf(content, "{\"switch_id\":\"%s\",\"location\":\"%s\",\"state\":\"%s\",\"result\":\"pulse triggered\"}",
 			context.switch_id, context.location, get_switch_state());
 		response_printf(info, call_result, content, id);
 	}
@@ -730,10 +742,10 @@ int loop()
 		if (absolute_time_diff_us(get_absolute_time(), led_time) < 0) {
 			led_time = make_timeout_time_ms(1000);
 		}
-        cyw43_arch_poll();
-        cyw43_arch_wait_for_work_until(led_time);
+		cyw43_arch_poll();
+		cyw43_arch_wait_for_work_until(led_time);
 #else
-        sleep_ms(1000);
+		sleep_ms(1000);
 #endif
 	}
 #if LWIP_MDNS_RESPONDER
@@ -757,6 +769,8 @@ int main()
 		printf("Wi-Fi init failed\n");
 		return -1;
 	}
+
+	init_atx_power_gpio();
 
 	while (true) {
 		loop();


### PR DESCRIPTION
### Motivation

- Replace the existing LED toggle behavior with a momentary ATX PWR_SW-style contact pulse so each API/Web call produces a one-shot pulse instead of maintaining ON/OFF state.  
- Ensure safety against repeated/overlapping requests by preventing a pulse from being held indefinitely and by returning a busy error when a pulse is already in progress.  
- Make GPIO, active level, and pulse width configurable for hardware flexibility and future changes.  
- Keep the existing JSON-RPC `set_switch` endpoint compatible while changing its internal behavior to always emit one pulse per request.

### Description

- Added configurable defaults `ATX_PWR_SW_GPIO`, `ATX_PWR_SW_ACTIVE_LEVEL`, and `ATX_PWR_SW_PULSE_MS` and replaced the `led_on` state with a `pulse_in_progress` guard.  
- Implemented `init_atx_power_gpio()` to initialize the pin and `atx_power_pulse()` to perform a safe one-shot pulse (sets active level, `sleep_ms(pulse_ms)`, then restore idle level).  
- Replaced the old `switch_led` logic with calls to `atx_power_pulse()` from `handle_set_switch()` and updated `get_switch_state()` and the JSON-RPC `tool_list`/responses to report `pulse triggered` or return a `Power pulse busy` error when concurrent.  
- Updated `main()` to call `init_atx_power_gpio()` at startup and updated `README.md` and `.editorconfig-checker.json` to reflect behavior and allow editorconfig checks to run.

Changed files (key diffs): `pico_mcp.c` (removed LED state handling, added `init_atx_power_gpio`, `atx_power_pulse`, `pulse_busy` response, modified `handle_set_switch` and `main`), `README.md` (describe ATX pulse behavior and config), `.editorconfig-checker.json` (exclude patterns/version update).

### Testing

- Ran `npx --yes editorconfig-checker` after updating `.editorconfig-checker.json`, and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966531262fc8324893373e1022adf0a)